### PR TITLE
Adding utf-8 encoding by default

### DIFF
--- a/hastebinit
+++ b/hastebinit
@@ -55,6 +55,7 @@ useful for keybindings.
         data = subprocess.check_output(["xclip", "-out"])
     else:
         data = args.file.read()
+    data = data.encode('utf-8')
 
     if args.xclip_output:
         # Set empty selection before doing remote requests.


### PR DESCRIPTION
By default, http.client encodes its data in iso-8859-1 (/usr/lib/python3.4/http/client.py:1102), I had a unicode file which made hastebinit crash.

Although I agree that encoding should be chosen by the user, I think that using unicode as default encoding is not a so bad choice.
